### PR TITLE
add basedir option

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ program
   .option('-P, --pretty', 'compile pretty html output')
   .option('-c, --client', 'compile function for client-side runtime.js')
   .option('-n, --name <str>', 'the name of the compiled template (requires --client)')
+  .option('-b, --basedir <path>', 'basedir path')
   .option('-D, --no-debug', 'compile without debugging (smaller functions)')
   .option('-w, --watch', 'watch files for changes and automatically re-render')
   .option('-E, --extension <ext>', 'specify the output file extension')
@@ -112,6 +113,11 @@ options.watch = program.watch;
 if (typeof program.name === 'string') {
   options.name = program.name;
 }
+
+// --basedir
+
+options.basedir = program.basedir || options.basedir;
+
 
 // --doctype
 

--- a/test/dependencies/extend2.pug
+++ b/test/dependencies/extend2.pug
@@ -1,0 +1,5 @@
+html
+    body
+        block container
+
+

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,7 @@ describe('command line with HTML output', function () {
       done();
     });
   });
+
   it("UTF newlines do not work in non-JSON object", function (done) {
     fs.writeFileSync(__dirname + '/temp/input.pug', '.foo= loc');
     fs.writeFileSync(__dirname + '/temp/input.html', '<p>output not written</p>');
@@ -149,6 +150,22 @@ describe('command line with HTML output', function () {
       if (err) return done(err);
       var html = fs.readFileSync(__dirname + '/temp/input.html', 'utf8');
       assert(html === '<div class="foo">str</div>');
+      done();
+    });
+  });
+  it('pug --no-debug --basedir ' + __dirname + '/temp/depwatch input.pug', function (done) {
+    function copy (file) {
+      fs.writeFileSync(__dirname + '/temp/depwatch/' + file + '.jade',
+        fs.readFileSync(__dirname + '/dependencies/' + file));
+    }
+    copy('extend2.pug');
+
+    fs.writeFileSync(__dirname + '/temp/input.pug', 'extends /extend2.pug');
+    fs.writeFileSync(__dirname + '/temp/input.html', '<p>extends extend2.pug fail</p>');
+    run(['--no-debug', "--basedir", __dirname + "/temp/depwatch", 'input.pug'], function (err) {
+      if (err) return done(err);
+      var html = fs.readFileSync(__dirname + '/temp/input.html', 'utf8');
+      assert(html === '<html><body></body></html>');
       done();
     });
   });


### PR DESCRIPTION
this is a short syntax for "jade --obj {\'basedir\':\'PATH\'} ..."
this is useful when we add comand in package.json file. you have to escape your quotes in package.json. 

it may looks like this:

```javascript

"jade": "jade  -E jinja --obj {\"basedir\":\\\"../\\\"} ../",

```

and this will make your code very very ugly.