### PR TITLE
Filters added to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ input is taken from standard input and output to standard output.
                        <dir>
 -p, --path <path>      filename used to resolve includes
 -P, --pretty           compile pretty HTML output
+-F, --filters <path>   path to custom filters module
 -c, --client           compile function for client-side runtime.js
 -n, --name <str>       the name of the compiled template (requires --client)
 -D, --no-debug         compile without debugging (smaller functions)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var program = require('commander');
 var mkdirp = require('mkdirp');
 var chalk = require('chalk');
 var pug = require('pug');
-var escapeRegex = require('escape-string-regexp');
 
 var basename = path.basename;
 var dirname = path.dirname;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ program
   .option('-o, --out <dir>', 'output the rendered HTML or compiled JavaScript to <dir>')
   .option('-p, --path <path>', 'filename used to resolve includes')
   .option('-P, --pretty', 'compile pretty html output')
+  .option('-F, --filters <path>', 'path to custom filters module')
   .option('-c, --client', 'compile function for client-side runtime.js')
   .option('-n, --name <str>', 'the name of the compiled template (requires --client)')
   .option('-D, --no-debug', 'compile without debugging (smaller functions)')
@@ -106,6 +107,16 @@ options.pretty = program.pretty || options.pretty;
 // --watch
 
 options.watch = program.watch;
+
+// --filters
+
+if (program.filters) {
+  try {
+    options.filters = require(join(process.cwd(), program.filters));
+  } catch (e) {
+    throw e;
+  }
+}
 
 // --name
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.8.1",
-    "escape-string-regexp": "^1.0.3",
     "pug": "^2.0.0-alpha1",
     "mkdirp": "^0.5.1"
   },


### PR DESCRIPTION
- Closes #15  
New CLI filters usage is:
`pug --filters pug.filters.js file.pug` or `pug -F pug.filters.js file.pug`, where `pug.filters.js` is a Node.js module of form:
```javascript
module.exports = {
  filter: function filterFunction (str, opts) {},
  filter2: function filter2Function (str, opts) {}
}
```
- Removes obsolete dependency `escape-string-regexp`