### PR TITLE
Display help when there is not an argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ program.on('--help', function(){
   console.log('');
 });
 
+if (process.argv.length === 2) {
+  program.help();
+}
+
 program.parse(process.argv);
 
 // options given, parse them


### PR DESCRIPTION
Hello:)

I display help when there is not an argument.
```
 ᐅ pug
  Usage:  [options] [dir|file ...]

  Options:

    -h, --help             output usage information
    -V, --version          output the version number
    -O, --obj <str|path>   JSON/JavaScript options object or file
    -o, --out <dir>        output the rendered HTML or compiled JavaScript to <dir>
    -p, --path <path>      filename used to resolve includes
    -P, --pretty           compile pretty html output
    -c, --client           compile function for client-side runtime.js
    -n, --name <str>       the name of the compiled template (requires --client)
    -D, --no-debug         compile without debugging (smaller functions)
    -w, --watch            watch files for changes and automatically re-render
    -E, --extension <ext>  specify the output file extension
    -s, --silent           do not output logs
    --name-after-file      name the template after the last section of the file path (requires --client and overriden by --name)
    --doctype <str>        specify the doctype on the command line (useful if it is not specified by the template)

  Examples:

    # Render all files in the `templates` directory:
    $ pug templates

    # Create {foo,bar}.html:
    $ pug {foo,bar}.pug

    # Using `pug` over standard input and output streams
    $ pug < my.pug > my.html
    $ echo 'h1 Pug!' | pug

    # Render all files in `foo` and `bar` directories to `/tmp`:
    $ pug foo bar --out /tmp
```

cheers.