### PR TITLE
Expose as pug-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-alpha6",
   "description": "Pug's CLI interface",
   "bin": {
-    "pug": "./index.js"
+    "pug": "./index.js",
+    "pug-cli": "./index.js"
   },
   "preferGlobal": true,
   "keywords": [],


### PR DESCRIPTION
Some people make the assumption that since the package name is pug-cli, the binary name will be pug-cli.  We should make that just work.

In addition, tools like `npx` also make this assumption, and we should probably try to support that.