### PR TITLE
Support YAML object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ input is taken from standard input and output to standard output.
 ```
 -h, --help             output usage information
 -V, --version          output the version number
--O, --obj <str|path>   JSON/JavaScript options object or file
+-O, --obj <str|path>   JSON/JavaScript/YAML options object or file
 -o, --out <dir>        output the rendered HTML or compiled JavaScript to
                        <dir>
 -p, --path <path>      filename used to resolve includes

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var program = require('commander');
 var mkdirp = require('mkdirp');
 var chalk = require('chalk');
 var pug = require('pug');
+var yaml = require('js-yaml');
 
 var basename = path.basename;
 var dirname = path.dirname;
@@ -98,7 +99,11 @@ function parseObj (input) {
     try {
       return JSON.parse(str);
     } catch (e) {
-      return eval('(' + str + ')');
+      try {
+        return yaml.safeLoad(str);
+      } catch (e) {
+        return eval('(' + str + ')');
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "commander": "^2.8.1",
-    "pug": "^2.0.0-alpha7",
-    "mkdirp": "^0.5.1"
+    "js-yaml": "^3.12.2",
+    "mkdirp": "^0.5.1",
+    "pug": "^2.0.0-alpha7"
   },
   "devDependencies": {
     "istanbul": "*",


### PR DESCRIPTION
I like YAML format because of its great readability, so I've made this program support YAML object.

Example command: `pug index.pug -O data.yaml` (just the same way as JSON object input)

If you like it, I would like you to consider merging this change.