### PR TITLE
allow symlink as input

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ function renderFile(path, rootPath) {
   var isPug = /\.(?:pug|jade)$/;
   var isIgnored = /([\/\\]_)|(^_)/;
 
-  var stat = fs.lstatSync(path);
+  var stat = fs.statSync(path);
   // Found pug file
   if (stat.isFile() && isPug.test(path) && !isIgnored.test(path)) {
     // Try to watch the file if needed. watchFile takes care of duplicates.


### PR DESCRIPTION
Previous implementation used 'lstatSync'  which returns stat info about link
itself, not the file that it refers to. That behaviour didn't allow to use the
tool in case of separate build (source and build dirs are separate, and sources
linked back into  build directory).

As workaround there we could provide file content through stdin, but that
approach has limitations:
- you cannot process multiple files at once
- you cannot use 'include' directives

This commit changes the use of  'lstatSync' to 'statSync' which makes symlink
files be processed as expected.