### PR TITLE
New mode added: -B --big-mode to compile in one file

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,10 +193,20 @@ function watchFile(path, base, rootPath) {
     if (curr.mtime.getTime() === 0) return;
     // istanbul ignore if
     if (curr.mtime.getTime() === prev.mtime.getTime()) return;
-    bigModeFirstFileWrote = false;
+    if (bigMode) {
+      bigModeReRenderAll();
+      return;
+    }
     watchList[path].forEach(function(file) {
       tryRender(file, rootPath);
     });
+  });
+}
+
+function bigModeReRenderAll() {
+  bigModeFirstFileWrote = false;
+  files.forEach(function (file) {
+    render(file);
   });
 }
 
@@ -296,10 +306,9 @@ function renderFile(path, rootPath) {
     mkdirp.sync(dir);
     var output = options.client ? fn : fn(options);
     if (bigMode) {
-
       fs[!bigModeFirstFileWrote ? 'writeFileSync' : 'appendFileSync'](program.big, output);
+      consoleLog('  ' + chalk.gray(`${bigModeFirstFileWrote ? 'appended' : 'writed'} ${path} to `) + ' ' + chalk.cyan('%s'), normalize(program.big));
       bigModeFirstFileWrote = true;
-      consoleLog('  ' + chalk.gray(`appended ${path} to `) + ' ' + chalk.cyan('%s'), normalize(program.big));
     } else {
       fs.writeFileSync(path, output);
       consoleLog('  ' + chalk.gray('rendered') + ' ' + chalk.cyan('%s'), normalize(path));

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ program
   .option('-b, --basedir <path>', 'path used as root directory to resolve absolute includes')
   .option('-P, --pretty', 'compile pretty HTML output')
   .option('-c, --client', 'compile function for client-side')
+  .option('-B, --big <path>', 'create all template functions in one file (works only with directory as source, implies --client and --name-after-file)')
   .option('-n, --name <str>', 'the name of the compiled template (requires --client)')
   .option('-D, --no-debug', 'compile without debugging (smaller functions)')
   .option('-w, --watch', 'watch files for changes and automatically re-render')
@@ -136,6 +137,13 @@ var watchList = {};
 // function for rendering
 var render = program.watch ? tryRender : renderFile;
 
+var bigMode = files.length && files.every(_ => fs.lstatSync(_).isDirectory()) && !!program.big;
+var bigModeFirstFileWrote = false;
+if (bigMode) {
+  options.client = true;
+  program.nameAfterFile = true;
+}
+
 // compile files
 
 if (files.length) {
@@ -185,6 +193,7 @@ function watchFile(path, base, rootPath) {
     if (curr.mtime.getTime() === 0) return;
     // istanbul ignore if
     if (curr.mtime.getTime() === prev.mtime.getTime()) return;
+    bigModeFirstFileWrote = false;
     watchList[path].forEach(function(file) {
       tryRender(file, rootPath);
     });
@@ -286,8 +295,15 @@ function renderFile(path, rootPath) {
     var dir = resolve(dirname(path));
     mkdirp.sync(dir);
     var output = options.client ? fn : fn(options);
-    fs.writeFileSync(path, output);
-    consoleLog('  ' + chalk.gray('rendered') + ' ' + chalk.cyan('%s'), normalize(path));
+    if (bigMode) {
+
+      fs[!bigModeFirstFileWrote ? 'writeFileSync' : 'appendFileSync'](program.big, output);
+      bigModeFirstFileWrote = true;
+      consoleLog('  ' + chalk.gray(`appended ${path} to `) + ' ' + chalk.cyan('%s'), normalize(program.big));
+    } else {
+      fs.writeFileSync(path, output);
+      consoleLog('  ' + chalk.gray('rendered') + ' ' + chalk.cyan('%s'), normalize(path));
+    }
   // Found directory
   } else if (stat.isDirectory()) {
     var files = fs.readdirSync(path);


### PR DESCRIPTION
For case where HTML rendering should occur on client, it is convinient 
to build one big file, with all generated template functions.
This mode assumes that directory should be given as source